### PR TITLE
HelpParams: Skip serializing if Option::is_none

### DIFF
--- a/types/bindings/index.d.ts
+++ b/types/bindings/index.d.ts
@@ -80,11 +80,11 @@ export interface HelpButton {
 }
 
 export interface HelpParams {
-  url: string | null;
-  number: string | null;
-  to: string | null;
-  subject: string | null;
-  body: string | null;
+  url?: string;
+  number?: string;
+  to?: string;
+  subject?: string;
+  body?: string;
 }
 
 export interface HelpResponse {

--- a/types/src/tools.rs
+++ b/types/src/tools.rs
@@ -14,10 +14,15 @@ pub struct HelpButton {
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct HelpParams {
+	#[serde(skip_serializing_if = "Option::is_none")]
 	url: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	number: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	to: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	subject: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	body: Option<String>,
 }
 


### PR DESCRIPTION
ccc-server doesn't include these and set them to null if not set, so we can mimic this behavior here as well. If the field isn't set in the source data, don't serialize it as `null`.