### PR TITLE
t/combine_types: Pass the --prefer-offline flag to npx

### DIFF
--- a/types/tests/combine_types.rs
+++ b/types/tests/combine_types.rs
@@ -55,8 +55,10 @@ fn find_relevant_sources(dir: &str) -> Result<impl Iterator<Item = PathBuf>, std
 /// Runs `npx prettier --write` on `path` and returns the `ExitStatus` of the underlying command.
 fn run_prettier(path: &Path) -> ExitStatus {
 	Command::new("npx")
+		.arg("--prefer-offline")
 		.arg("prettier")
 		.arg("--write")
+		.arg("--")
 		.arg(path.as_os_str())
 		.status()
 		.expect("failed to determine exit status")


### PR DESCRIPTION
`npm help exec` has this to say about the flag:

```console
   prefer-offline
       Bypasses staleness checks for packages.  Missing data will still be requested from the server. To
       force full offline mode, use offline.
```

In testing, this allows me to run the test suite with my Wi-Fi turned off, so this closes #8.