### PR TITLE
Include lint configuration in all crates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run clippy
       run: |
         rustup component add clippy
-        cargo clippy --workspace --all-features --all-targets -- -D clippy::all -W clippy::cargo -W clippy::pedantic -W clippy::cognitive-complexity
+        cargo clippy --workspace --all-features --all-targets
   test:
     name: Test the code
     runs-on: ubuntu-latest

--- a/handlers/src/lib.rs
+++ b/handlers/src/lib.rs
@@ -1,1 +1,4 @@
+#![deny(clippy::all)]
+#![warn(clippy::cargo, clippy::pedantic, clippy::cognitive_complexity)]
+
 pub mod github;

--- a/routes/src/lib.rs
+++ b/routes/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![warn(clippy::cargo, clippy::pedantic, clippy::cognitive_complexity)]
+
 pub mod contacts;
 pub mod dictionary;
 pub mod faqs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![warn(clippy::cargo, clippy::pedantic, clippy::cognitive_complexity)]
+
 use axum::{
 	body::Body,
 	error_handling::HandleErrorLayer,

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![warn(clippy::cargo, clippy::pedantic, clippy::cognitive_complexity)]
+
 pub mod contacts;
 pub mod dictionary;
 pub mod faqs;


### PR DESCRIPTION
Rather than relying on a big long special command getting run, (`cargo clippy --workspace --all-targets --all-features -- <all of the configuration stuff>`) we can actually inline this configuration by using an _inner attribute_ on each of the targets' main files (`lib.rs` for a library, `main.rs` for a binary).  Note that `src/main.rs` is the target for the server binary, whereas `handlers`, `routes`, and `types` each have a `src/lib.rs` where this is applied instead.

This should produce identical results to what we got with the special CI configuration.  Now it's tracked in the code, though, so any changes to the configuration should go there (and be done across all the crates).