### PR TITLE
Axum 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,9 +27,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -45,8 +45,10 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -58,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
 dependencies = [
  "async-trait",
  "bytes",
@@ -68,15 +70,16 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-macros"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6293dae2ec708e679da6736e857cf8532886ef258e92930f38279c12641628b8"
+checksum = "e4df0fc33ada14a338b799002f7e8657711422b25d4e16afb032708d6b185621"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -444,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -750,6 +753,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +825,15 @@ checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "serde",
  "tokio",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "types",
@@ -1059,6 +1060,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ routes = { path = "./routes" }
 reqwest = { version = "0.11.11", features = ["json"] }
 serde = { version = "1.0.139", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["macros", "rt-multi-thread"] }
-tower = { version = "0.4.13", features = ["filter"] }
+tower = { version = "0.4.13", features = ["filter", "timeout"] }
+tower-http = { version = "0.3.5", features = ["trace"] }
 tracing = "0.1.35"
 tracing-subscriber = "0.3.14"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.5.13"
+axum = "0.6.1"
 types = { path = "./types" }
 routes = { path = "./routes" }
 reqwest = { version = "0.11.11", features = ["json"] }

--- a/handlers/Cargo.toml
+++ b/handlers/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.5.13"
-axum-macros = "0.2.3"
+axum = "0.6.1"
+axum-macros = "0.3.0"
 http = "0.2.8"
 types = { path = "../types" }
 reqwest = { version = "0.11.11", features = ["json"] }

--- a/routes/Cargo.toml
+++ b/routes/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-axum = "0.5.13"
+axum = "0.6.1"
 handlers = { path = "../handlers" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,7 @@ use axum::{
 use tower::ServiceBuilder;
 
 fn init_router() -> Router {
-	let middleware_stack = ServiceBuilder::new().layer(HandleErrorLayer::new(|error| async move {
-		(
-			StatusCode::INTERNAL_SERVER_ERROR,
-			format!("Unhandled Internal Error: {error}"),
-		)
-	}));
+	let middleware_stack = ServiceBuilder::new().layer(HandleErrorLayer::new(error_handler));
 
 	let meta_routes = Router::new()
 		.route("/", get(root_handler))
@@ -47,6 +42,14 @@ async fn main() {
 		.serve(app.into_make_service())
 		.await
 		.expect("server failed to exit successfully");
+}
+
+#[allow(clippy::unused_async)]
+async fn error_handler<E: std::error::Error>(error: E) -> impl IntoResponse {
+	(
+		StatusCode::INTERNAL_SERVER_ERROR,
+		format!("Unhandled Internal Error: {error}"),
+	)
 }
 
 #[allow(clippy::unused_async)]


### PR DESCRIPTION
[axum v0.6.0 release notes](https://github.com/tokio-rs/axum/releases/tag/axum-v0.6.0)

- This required removing the `map_request` and `map_response` middlewares.
  - The main thing about this is that the `/v1` part of the route is missing now. 
  - It's possible we could do the server-side routing some other way. If we want to version to maintain backwards-compatibility, we could do that through a custom `Layer`.

- I also added a `TimeoutLayer` and a `TraceLayer` to add tracing and timeouts.