### PR TITLE
Use frogpond fork of ts-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,7 +1257,7 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "ts-rs"
 version = "6.2.0"
-source = "git+https://github.com/frog-pond/ts-rs.git?branch=resolve-clippy-useless_vec#93f786fed3f556e91f6ac368755dd7df60ebc89d"
+source = "git+https://github.com/frog-pond/ts-rs.git?tag=6.2.2#b30dd408b74ea117d8d6cd2f05af9b7dc26f9f2a"
 dependencies = [
  "thiserror",
  "ts-rs-macros",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "ts-rs-macros"
 version = "6.2.0"
-source = "git+https://github.com/frog-pond/ts-rs.git?branch=resolve-clippy-useless_vec#93f786fed3f556e91f6ac368755dd7df60ebc89d"
+source = "git+https://github.com/frog-pond/ts-rs.git?tag=6.2.2#b30dd408b74ea117d8d6cd2f05af9b7dc26f9f2a"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,9 +1256,8 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "ts-rs"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4added4070a4fdf9df03457206cd2e4b12417c8560a2954d91ffcbe60177a56a"
+version = "6.2.0"
+source = "git+https://github.com/frog-pond/ts-rs.git?branch=resolve-clippy-useless_vec#93f786fed3f556e91f6ac368755dd7df60ebc89d"
 dependencies = [
  "thiserror",
  "ts-rs-macros",
@@ -1267,8 +1266,7 @@ dependencies = [
 [[package]]
 name = "ts-rs-macros"
 version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f807fdb3151fee75df7485b901a89624358cd07a67a8fb1a5831bf5a07681ff"
+source = "git+https://github.com/frog-pond/ts-rs.git?branch=resolve-clippy-useless_vec#93f786fed3f556e91f6ac368755dd7df60ebc89d"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/ccc-types/Cargo.toml
+++ b/ccc-types/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 [dependencies]
 serde = { version = "1.0.176", features = ["derive"] }
 serde_json = "1.0.102"
-ts-rs = {version = "6.2.1" }
+ts-rs = { git = 'https://github.com/frog-pond/ts-rs.git', branch = 'resolve-clippy-useless_vec' }

--- a/ccc-types/Cargo.toml
+++ b/ccc-types/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 [dependencies]
 serde = { version = "1.0.176", features = ["derive"] }
 serde_json = "1.0.102"
-ts-rs = { git = 'https://github.com/frog-pond/ts-rs.git', branch = 'resolve-clippy-useless_vec' }
+ts-rs = { git = 'https://github.com/frog-pond/ts-rs.git', tag = '6.2.2' }


### PR DESCRIPTION
@rye did all of the work.
- Replaces the upstream fork of `ts-rs` with the one now forked into our own org. 
- Resolves #83 


Quoting @rye 
> Beta clippy recently started failing on a downstream consumer (issue) of this crate. This was because of a number of calls to vec! that were picked up by clippy. This lint only fires, at time of writing, in beta (stable does not have the change that introduced it, and nightly has since changed to ignore this lint in macros...). This will, assuming this change gets released quickly, help fellow `#![deny(clippy::all)]` folks who use this crate.
>
> Also removes some trailing whitespace in `ts-rs/src/lib.rs` in `d4dfefe`