### PR TITLE
github: Make errors a lot more helpful

### DIFF
--- a/ccc-handlers/src/github.rs
+++ b/ccc-handlers/src/github.rs
@@ -100,10 +100,7 @@ where
 
 impl IntoResponse for JsonProxyError {
 	fn into_response(self) -> axum::response::Response {
-		// [this is a stub, where `self` is JsonProxyError]
-		let text = match self {
-			Self::Request(e) => e.to_string(),
-		};
+		let text = self.to_string();
 
 		let body = axum::body::boxed(axum::body::Full::from(text));
 


### PR DESCRIPTION
Before this set of changes, we would get the following error: `error during proxied request`.

With a bit of `thiserror` magic and the use of a shim that manually parses the response data and includes it in the error message if it is returned, we now get messages much more helpful:

```
error while parsing proxied response from github (missing field `fall` at line 1 column 263):
{ /* ... */ }
```