### PR TITLE
Implement a shared proxy framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ccc-proxy"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ccc-routes"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "axum-macros",
+ "ccc-proxy",
  "ccc-types",
  "http",
  "phf",
@@ -176,6 +177,9 @@ dependencies = [
 name = "ccc-proxy"
 version = "0.1.0"
 dependencies = [
+ "axum",
+ "bytes",
+ "http",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
 	"ccc-server",
 	"ccc-handlers",
+	"ccc-proxy",
 	"ccc-routes",
 	"ccc-types",
 	"e2e",

--- a/ccc-handlers/Cargo.toml
+++ b/ccc-handlers/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
+ccc-proxy = { path = "../ccc-proxy" }
+ccc-types = { path = "../ccc-types" }
 axum = "0.6.20"
 axum-macros = "0.3.8"
 http = "0.2.9"
-ccc-types = { path = "../ccc-types" }
 reqwest = { version = "0.11.18", features = ["json"] }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.104"

--- a/ccc-handlers/src/bonapp.rs
+++ b/ccc-handlers/src/bonapp.rs
@@ -1,78 +1,42 @@
 use core::ops::DerefMut;
-use std::sync::OnceLock;
 
 use axum::{
 	extract::Path,
 	response::{IntoResponse, Response},
 	Json,
 };
+use ccc_proxy::ProxyError;
 use http::StatusCode;
 use tracing::instrument;
 
-struct BonAppProxy {
-	client: Option<reqwest::Client>,
+#[instrument]
+async fn send_proxied_query<T>(
+	query_type: QueryType,
+	entity_id: &str,
+) -> Result<Json<T>, BonAppProxyError>
+where
+	T: serde::de::DeserializeOwned,
+{
+	tracing::debug!(entity_id, ?query_type, "handling proxied BonApp request");
+
+	let (base_url, entity) = get_query_base_url_and_entity(&query_type);
+
+	let request = ccc_proxy::global_proxy()
+		.client()
+		.request(http::Method::GET, base_url)
+		.query(&[(entity, entity_id)])
+		.build()
+		.map_err(ProxyError::ProxiedRequest)
+		.map_err(BonAppProxyError::GenericProxy)?;
+
+	ccc_proxy::global_proxy()
+		.send_request_parse_json::<T>(request)
+		.await
+		.map(Json)
+		.map_err(BonAppProxyError::GenericProxy)
 }
 
-static GLOBAL_BONAPP_PROXY: OnceLock<BonAppProxy> = OnceLock::new();
-
-impl BonAppProxy {
-	fn handle() -> &'static BonAppProxy {
-		GLOBAL_BONAPP_PROXY.get_or_init(|| {
-			let client = reqwest::Client::builder()
-				.user_agent("ccc-server-next/0.0.0")
-				.build()
-				.unwrap();
-
-			BonAppProxy {
-				client: Some(client),
-			}
-		})
-	}
-}
-
-impl BonAppProxy {
-	#[instrument(skip(self))]
-	async fn send_proxied_query<T>(
-		&self,
-		query_type: QueryType,
-		entity_id: &str,
-	) -> Result<Json<T>, BonAppProxyError>
-	where
-		T: serde::de::DeserializeOwned,
-	{
-		tracing::debug!(entity_id, ?query_type, "handling proxied BonApp request");
-
-		let base_url = get_query_base_url(&query_type);
-		let id = entity_id.to_string();
-
-		let url: String = build_query_url(&query_type, base_url, id)?;
-
-		tracing::debug!(?url, "sending proxied request");
-
-		let response = match &self.client {
-			Some(client) => {
-				client
-					.execute(client.get(url).build().map_err(BonAppProxyError::Request)?)
-					.await
-			}
-			None => {
-				tracing::warn!(
-					"shared client was not initialized; falling back on inefficient request handler!"
-				);
-				reqwest::get(url).await
-			}
-		};
-
-		// let response = reqwest::get(url).await;
-
-		tracing::debug!(?response, "got response");
-
-		let response = response.map_err(BonAppProxyError::Request)?;
-
-		parse_response::<T>(response).await
-	}
-}
-
+/// Map which stores mappings of known cafe names to cafe IDs.
 const CAFE_NAME_MAP: phf::Map<&str, u32> = phf::phf_map! {
 	"stav-hall" => 261,
 	"the-cage" => 262,
@@ -85,39 +49,11 @@ const CAFE_NAME_MAP: phf::Map<&str, u32> = phf::phf_map! {
 
 #[derive(thiserror::Error, Debug)]
 pub enum BonAppProxyError {
-	#[error("error while encoding query string")]
-	QueryStringEncoding(#[from] serde_urlencoded::ser::Error),
-
-	#[error("error while sending proxied request to bonapp")]
-	Request(reqwest::Error),
-
-	#[error("error while receiving proxied response from bonapp ({0})")]
-	ResponseAcquisition(reqwest::Error),
-
-	#[error("error while parsing proxied response from bonapp ({0}):\n{1}")]
-	ResponseParse(serde_json::Error, String),
-
 	#[error("unknown cafe")]
 	UnknownCafe,
-}
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(untagged)]
-enum ProxyRequestQueryParameters {
-	Cafe { cafe: String },
-	Menu { cafe: String },
-	ItemNutrition { item: String },
-}
-
-#[test]
-fn query_parameters_serialize() {
-	let query = ProxyRequestQueryParameters::Cafe {
-		cafe: "foo".to_string(),
-	};
-	assert_eq!(
-		serde_urlencoded::to_string(query).ok(),
-		Some("cafe=foo".to_string())
-	);
+	#[error("error from generic proxy: {0}")]
+	GenericProxy(ProxyError),
 }
 
 #[derive(Debug)]
@@ -127,46 +63,15 @@ enum QueryType {
 	ItemNutrition,
 }
 
-#[instrument]
-async fn parse_response<T>(response: reqwest::Response) -> Result<Json<T>, BonAppProxyError>
-where
-	T: serde::de::DeserializeOwned,
-{
-	let response = response
-		.text()
-		.await
-		.map_err(BonAppProxyError::ResponseAcquisition)?;
-
-	let json = serde_json::from_str(&response);
-
-	match json {
-		Ok(value) => Ok(Json(value)),
-		Err(e) => Err(BonAppProxyError::ResponseParse(e, response)),
-	}
-}
+use QueryType::*;
 
 #[inline]
-const fn get_query_base_url(query_type: &QueryType) -> &str {
-	use QueryType::*;
+const fn get_query_base_url_and_entity(query_type: &QueryType) -> (&str, &str) {
 	match query_type {
-		Cafe => "https://legacy.cafebonappetit.com/api/2/cafes",
-		Menu => "https://legacy.cafebonappetit.com/api/2/menus",
-		ItemNutrition => "https://legacy.cafebonappetit.com/api/2/items",
+		Cafe => ("https://legacy.cafebonappetit.com/api/2/cafes", "cafe"),
+		Menu => ("https://legacy.cafebonappetit.com/api/2/menus", "cafe"),
+		ItemNutrition => ("https://legacy.cafebonappetit.com/api/2/items", "item"),
 	}
-}
-
-fn build_query_url(
-	query_type: &QueryType,
-	base_url: &str,
-	id: String,
-) -> Result<String, BonAppProxyError> {
-	let params = match query_type {
-		QueryType::Cafe => ProxyRequestQueryParameters::Cafe { cafe: id },
-		QueryType::Menu => ProxyRequestQueryParameters::Menu { cafe: id },
-		QueryType::ItemNutrition => ProxyRequestQueryParameters::ItemNutrition { item: id },
-	};
-	let url = format!("{}?{}", base_url, serde_urlencoded::to_string(params)?);
-	Ok(url)
 }
 
 #[instrument(skip_all)]
@@ -197,8 +102,7 @@ pub async fn named_cafe_menu_handler(
 pub async fn cafe_handler(
 	Path(cafe_id): Path<String>,
 ) -> Result<Json<ccc_types::food::BonAppCafeResponse>, BonAppProxyError> {
-	BonAppProxy::handle()
-		.send_proxied_query::<ccc_types::food::BonAppCafesResponse>(QueryType::Cafe, &cafe_id)
+	send_proxied_query::<ccc_types::food::BonAppCafesResponse>(Cafe, &cafe_id)
 		.await
 		.map(|mut result| {
 			let cafes = result.deref_mut().cafes_mut();
@@ -219,11 +123,7 @@ pub async fn cafe_handler(
 pub async fn cafe_menu_handler(
 	Path(cafe_id): Path<String>,
 ) -> Result<Json<ccc_types::food::BonAppMenuSingleCafeResponse>, BonAppProxyError> {
-	BonAppProxy::handle()
-		.send_proxied_query::<ccc_types::food::BonAppMenuMultipleCafesResponse>(
-			QueryType::Menu,
-			&cafe_id,
-		)
+	send_proxied_query::<ccc_types::food::BonAppMenuMultipleCafesResponse>(Menu, &cafe_id)
 		.await
 		.map(|Json(result)| Json(result.as_single_day_response(&cafe_id)))
 }
@@ -232,9 +132,7 @@ pub async fn cafe_menu_handler(
 pub async fn nutrition_handler(
 	Path(item_id): Path<String>,
 ) -> Result<Json<ccc_types::food::ItemNutritionResponse>, BonAppProxyError> {
-	BonAppProxy::handle()
-		.send_proxied_query(QueryType::ItemNutrition, &item_id)
-		.await
+	send_proxied_query(ItemNutrition, &item_id).await
 }
 
 impl IntoResponse for BonAppProxyError {

--- a/ccc-proxy/Cargo.toml
+++ b/ccc-proxy/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+axum = "0.6.20"
+bytes = "1.4.0"
+http = "0.2.9"
 reqwest = { version = "0.11.18", features = ["json"] }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.104"

--- a/ccc-proxy/Cargo.toml
+++ b/ccc-proxy/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ccc-proxy"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+reqwest = { version = "0.11.18", features = ["json"] }
+serde = { version = "1.0.183", features = ["derive"] }
+serde_json = "1.0.104"

--- a/ccc-proxy/Cargo.toml
+++ b/ccc-proxy/Cargo.toml
@@ -10,3 +10,5 @@ publish = false
 reqwest = { version = "0.11.18", features = ["json"] }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.104"
+thiserror = { version = "1.0.44" }
+tracing = "0.1.37"

--- a/ccc-proxy/src/lib.rs
+++ b/ccc-proxy/src/lib.rs
@@ -1,6 +1,113 @@
+use std::sync::OnceLock;
+
+use axum::response::{IntoResponse, Response};
+use bytes::Bytes;
+use http::StatusCode;
+use reqwest::{header::HeaderValue, Request};
+use serde::de::DeserializeOwned;
+use tracing::instrument;
+
 pub struct Proxy {
-	_client: Option<reqwest::Client>,
+	client: reqwest::Client,
+}
+
+pub static GLOBAL_PROXY: OnceLock<Proxy> = OnceLock::new();
+
+pub fn global_proxy() -> &'static Proxy {
+	GLOBAL_PROXY.get_or_init(|| Proxy::default())
+}
+
+fn user_agent() -> HeaderValue {
+	let user_agent = match std::env::var("CCC_USER_AGENT") {
+		Ok(env_variable) => env_variable,
+		Err(_) => format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
+	};
+
+	HeaderValue::from_str(&user_agent).expect("user-agent should be a valid value")
+}
+
+impl Default for Proxy {
+	fn default() -> Self {
+		let client = reqwest::Client::builder()
+			.user_agent(user_agent())
+			.build()
+			.unwrap();
+
+		Self { client }
+	}
+}
+
+impl Proxy {
+	pub fn client(&self) -> &reqwest::Client {
+		&self.client
+	}
+
+	#[instrument(skip(self))]
+	pub async fn send_request(&self, request: Request) -> Result<Bytes, ProxyError> {
+		tracing::trace!(?request, "sending proxied request");
+
+		let response = self
+			.client
+			.execute(request)
+			.await
+			.map_err(ProxyError::ProxiedRequest)?;
+
+		tracing::trace!(?response, "received proxied response");
+
+		let response = response
+			.bytes()
+			.await
+			.map_err(ProxyError::ProxiedResponse)?;
+
+		tracing::trace!(?response, "collected proxied response bytes");
+
+		Ok(response)
+	}
+
+	#[instrument(skip(self))]
+	pub async fn send_request_parse_json<T>(&self, request: Request) -> Result<T, ProxyError>
+	where
+		T: DeserializeOwned,
+	{
+		let bytes: Bytes = self.send_request(request).await?;
+
+		let string = core::str::from_utf8(&bytes).map(|str| str.to_string());
+		let parsed = serde_json::from_slice(&bytes);
+
+		match (parsed, string) {
+			(Ok(object), _) => Ok(object),
+			(Err(parse_err), Ok(str)) => Err(ProxyError::ParseProxiedResponse(parse_err, str)),
+			(Err(parse_err), Err(_e)) => Err(ProxyError::ParseProxiedResponse(
+				parse_err,
+				"<invalid utf8>".to_string(),
+			)),
+		}
+	}
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum ProxyError {}
+pub enum ProxyError {
+	#[error("error sending proxied request: {0}")]
+	ProxiedRequest(reqwest::Error),
+
+	#[error("error receiving proxied response: {0}")]
+	ProxiedResponse(reqwest::Error),
+
+	#[error("error parsing proxied response data as JSON: {0}\n{1}")]
+	ParseProxiedResponse(serde_json::Error, String),
+}
+
+impl IntoResponse for ProxyError {
+	fn into_response(self) -> Response {
+		use axum::body;
+
+		let text = self.to_string();
+
+		let body = body::boxed(body::Full::from(text));
+
+		Response::builder()
+			.status(StatusCode::INTERNAL_SERVER_ERROR)
+			.body(body)
+			.unwrap()
+	}
+}

--- a/ccc-proxy/src/lib.rs
+++ b/ccc-proxy/src/lib.rs
@@ -1,5 +1,6 @@
 pub struct Proxy {
-	client: Option<reqwest::Client>,
+	_client: Option<reqwest::Client>,
 }
 
+#[derive(thiserror::Error, Debug)]
 pub enum ProxyError {}

--- a/ccc-proxy/src/lib.rs
+++ b/ccc-proxy/src/lib.rs
@@ -1,0 +1,5 @@
+pub struct Proxy {
+	client: Option<reqwest::Client>,
+}
+
+pub enum ProxyError {}


### PR DESCRIPTION
Both the GitHub and BonApp handlers had their own proxy error types and their own implementations each calling `reqwest::get`. This led to a couple of problems:

1. `reqwest::get` would allocate a new `reqwest::Client` _every_ time a request came in. This meant that features like connection pooling could not work, and we were generally more wasteful.
2. `reqwest::get` offers no mechanism to control the `user-agent` header.

With the way the handlers were written, a future attempt to centralize this logic and add features like caching and single-flighting would have required repeated updates across multiple modules.

In this PR I create yet another crate, `ccc-proxy`, which will house generic logic that all handlers can call into to get a request. `ccc-proxy` also includes a `global_proxy()` function which will either initialize or return a shared instance of a `reqwest::Client` that can be shared across threads. It only gets initialized once.

I also adjusted the logging a bit to dump more of the information I find helpful while debugging.

