### PR TITLE
cargo: Remove explicit dependency on http crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 0.2.11",
+ "http",
  "http-body",
  "hyper",
  "itoa",
@@ -140,7 +140,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.11",
+ "http",
  "http-body",
  "mime",
  "rustversion",
@@ -232,7 +232,6 @@ dependencies = [
  "axum-macros",
  "ccc-proxy",
  "ccc-types",
- "http 1.0.0",
  "phf",
  "reqwest",
  "serde",
@@ -248,7 +247,6 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "bytes",
- "http 1.0.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -520,7 +518,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -543,7 +541,7 @@ dependencies = [
  "base64",
  "bytes",
  "headers-core",
- "http 0.2.11",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -555,7 +553,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.11",
+ "http",
 ]
 
 [[package]]
@@ -582,24 +580,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http 0.2.11",
+ "http",
  "pin-project-lite",
 ]
 
@@ -632,7 +619,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1057,7 +1044,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -1455,7 +1442,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.11",
+ "http",
  "http-body",
  "http-range-header",
  "pin-project-lite",

--- a/ccc-handlers/Cargo.toml
+++ b/ccc-handlers/Cargo.toml
@@ -9,7 +9,6 @@ ccc-proxy = { path = "../ccc-proxy" }
 ccc-types = { path = "../ccc-types" }
 axum = "0.6.20"
 axum-macros = "0.3.8"
-http = "1.0.0"
 reqwest = { version = "0.11.22", features = ["json"] }
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.108"

--- a/ccc-proxy/Cargo.toml
+++ b/ccc-proxy/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 axum = "0.6.20"
 bytes = "1.5.0"
-http = "1.0.0"
 reqwest = { version = "0.11.22", features = ["json"] }
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.108"


### PR DESCRIPTION
Since 77ecb2e7d49eccb56ee220e6a7105f52347d8e4c, we are using the reqwest re-exports of the items from the http crate. This means we no longer need to have the two versions (reqwest's version and ours).