### PR TITLE
axum compat fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .env
+.DS_STORE

--- a/ccc-routes/src/food.rs
+++ b/ccc-routes/src/food.rs
@@ -8,10 +8,10 @@ use ccc_handlers::{
 
 pub fn router() -> Router {
 	Router::new()
-		.route("/menu/:cafe_id", get(cafe_menu_handler))
-		.route("/cafe/:cafe_id", get(cafe_handler))
-		.route("/item/:item_id", get(nutrition_handler))
-		.route("/named/cafe/:name", get(named_cafe_handler))
-		.route("/named/menu/:name", get(named_cafe_menu_handler))
+		.route("/menu/{cafe_id}", get(cafe_menu_handler))
+		.route("/cafe/{cafe_id}", get(cafe_handler))
+		.route("/item/{item_id}", get(nutrition_handler))
+		.route("/named/cafe/{name}", get(named_cafe_handler))
+		.route("/named/menu/{name}", get(named_cafe_menu_handler))
 		.route("/named/menu/the-pause", get(pause_menu_handler))
 }

--- a/ccc-routes/src/food.rs
+++ b/ccc-routes/src/food.rs
@@ -12,6 +12,6 @@ pub fn router() -> Router {
 		.route("/cafe/{cafe_id}", get(cafe_handler))
 		.route("/item/{item_id}", get(nutrition_handler))
 		.route("/named/cafe/{name}", get(named_cafe_handler))
-		.route("/named/menu/{name}", get(named_cafe_menu_handler))
 		.route("/named/menu/the-pause", get(pause_menu_handler))
+		.route("/named/menu/{name}", get(named_cafe_menu_handler))
 }

--- a/ccc-server/src/main.rs
+++ b/ccc-server/src/main.rs
@@ -52,7 +52,7 @@ fn init_router() -> Router {
 		.nest("/webcams", ccc_routes::webcams::router());
 
 	Router::new()
-		.nest("/", meta_routes)
+		.merge(meta_routes)
 		.nest("/api", api_routes)
 		.layer(middleware_stack)
 		.fallback(fallback)


### PR DESCRIPTION
- adds compatibility for breaking changes introduced by Axum upgrade in #220 
- fix axum route parameter parsing
- fix top-level routes that muse be merged and not nested
- gitignore addition