### PR TITLE
Migrate lint configuration to workspace-level Cargo configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ members = [
 	"e2e",
 ]
 
+[workspace.lints.clippy]
+all = "deny"
+cargo = "warn"
+pedantic = "warn"
+cognitive_complexity = "warn"
+
 [workspace.dependencies]
 axum = "0.8.0"
 axum-macros = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.lints.clippy]
-all = "deny"
+all = { level = "deny", priority = -1 }
 cargo = "warn"
 pedantic = "warn"
 cognitive_complexity = "warn"

--- a/ccc-handlers/Cargo.toml
+++ b/ccc-handlers/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 ccc-proxy = { workspace = true }
 ccc-types = { workspace = true }

--- a/ccc-handlers/src/lib.rs
+++ b/ccc-handlers/src/lib.rs
@@ -1,6 +1,3 @@
-#![deny(clippy::all)]
-#![warn(clippy::cargo, clippy::pedantic, clippy::cognitive_complexity)]
-
 pub mod bonapp;
 pub mod github;
 pub mod reports;

--- a/ccc-proxy/Cargo.toml
+++ b/ccc-proxy/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 axum = { workspace = true }

--- a/ccc-routes/Cargo.toml
+++ b/ccc-routes/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 axum = { workspace = true }
 ccc-handlers = { workspace = true }

--- a/ccc-routes/src/lib.rs
+++ b/ccc-routes/src/lib.rs
@@ -1,6 +1,3 @@
-#![deny(clippy::all)]
-#![warn(clippy::cargo, clippy::pedantic, clippy::cognitive_complexity)]
-
 pub mod contacts;
 pub mod dictionary;
 pub mod faqs;

--- a/ccc-server/Cargo.toml
+++ b/ccc-server/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 axum = { workspace = true }
 clap = { workspace = true }

--- a/ccc-server/src/main.rs
+++ b/ccc-server/src/main.rs
@@ -1,6 +1,3 @@
-#![deny(clippy::all)]
-#![warn(clippy::cargo, clippy::pedantic, clippy::cognitive_complexity)]
-
 use axum::{
 	error_handling::HandleErrorLayer, http::StatusCode, response::IntoResponse, routing::get,
 	BoxError, Router,

--- a/ccc-types/Cargo.toml
+++ b/ccc-types/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/ccc-types/src/lib.rs
+++ b/ccc-types/src/lib.rs
@@ -1,6 +1,3 @@
-#![deny(clippy::all)]
-#![warn(clippy::cargo, clippy::pedantic, clippy::cognitive_complexity)]
-
 pub mod contacts;
 pub mod dictionary;
 pub mod faqs;

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "AGPL-3.0-only"
 description = "End-to-end tests for the project"
 
+[lints]
+workspace = true
+
 [dependencies]
 tokio = { workspace = true }
 reqwest = { workspace = true }


### PR DESCRIPTION
Since Rust 1.74, it's been possible to define [workspace-level lints](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-lints-table).

With this PR, the old hard-coded clippy lint configuration gets pulled out into keys defined at the workspace level.

Additionally, the `ccc-types` and `e2e` crates begin inheriting lint configuration from the workspace-level Cargo.toml file.