### PR TITLE
Set MSRV to 1.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ members = [
 	"e2e",
 ]
 
+[workspace.package]
+rust-version = "1.74"
+
 [workspace.dependencies]
 axum = "0.8.0"
 axum-macros = "0.5.0"

--- a/ccc-handlers/Cargo.toml
+++ b/ccc-handlers/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-handlers"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version.workspace = true
 
 [dependencies]
 ccc-proxy = { workspace = true }

--- a/ccc-proxy/Cargo.toml
+++ b/ccc-proxy/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-proxy"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ccc-routes/Cargo.toml
+++ b/ccc-routes/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-routes"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version.workspace = true
 
 [dependencies]
 axum = { workspace = true }

--- a/ccc-server/Cargo.toml
+++ b/ccc-server/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-server"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version.workspace = true
 
 [dependencies]
 axum = { workspace = true }

--- a/ccc-types/Cargo.toml
+++ b/ccc-types/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-types"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version.workspace = true
 
 [dependencies]
 serde = { workspace = true }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "End-to-end tests for the project"
+rust-version.workspace = true
 
 [dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
Announced in 2023-11, Rust 1.74 added some workspace-level configuration options I want to use in #258.

Before doing so we should probably set a MSRV.

The MSRV of the `workspace.package.rust-version` appears to be 1.64+.