### PR TITLE
Fix new clippy lints with combine_types

### DIFF
--- a/ccc-types/tests/combine_types.rs
+++ b/ccc-types/tests/combine_types.rs
@@ -45,7 +45,6 @@ fn should_consider_entry(dir_entry: &DirEntry) -> bool {
 fn find_relevant_sources(dir: &str) -> Result<impl Iterator<Item = PathBuf>, std::io::Error> {
 	Ok(
 		read_dir(dir)?
-			.into_iter()
 			.filter_map(Result::ok)
 			.filter(should_consider_entry)
 			.map(|dir_entry| dir_entry.path()),
@@ -84,12 +83,12 @@ fn generate_tscode(paths: &BTreeSet<PathBuf>) -> Result<String, std::io::Error> 
 
 	// For each path, open and read the file, appending lines to be included to `output`.
 	for path in paths {
-		let file = File::open(&path)?;
+		let file = File::open(path)?;
 		let reader = BufReader::new(file);
 
 		for line in reader
 			.lines()
-			.flatten()
+			.map_while(Result::ok)
 			.filter(|line| should_include(line.as_str()))
 		{
 			output.push_str(&line);


### PR DESCRIPTION
- [`ReadDir` is already an iterator](https://doc.rust-lang.org/stable/std/fs/struct.ReadDir.html). No need to call `.into_iter()` on it. (`clippy::useless_conversion`)
- When iterating over `paths`, `path` has type `&PathBuf` which implements the required traits for `File::open`. No need for a borrow when passing the path into the function. (`clippy::needless_borrows_for_generic_args`)
- If for some reason the `Lines` produced by `reader.lines()` is invoked in an error state, it may produce an infinite number of `Err` objects, causing the `flatten` to never complete. Instead, just take the `Ok` variants by using `map_while(Result::ok)`.