### PR TITLE
server: Build and initialize runtime by hand

### DIFF
--- a/ccc-server/src/rt.rs
+++ b/ccc-server/src/rt.rs
@@ -1,0 +1,8 @@
+use tokio::{
+	io,
+	runtime::{Builder, Runtime},
+};
+
+pub(super) fn normal() -> io::Result<Runtime> {
+	Builder::new_multi_thread().enable_all().build()
+}


### PR DESCRIPTION
This gives us sufficient control over the startup process to add in additional streams of work like backend workers, a step towards #13.

While we _could_ continue to use the `tokio::main` macro in the server to hide these details, this approach helps make it more obvious how everything is working under the hood and gives us more control over how the runtime is built and ultimately run. It's [essentially equivalent](https://docs.rs/tokio/latest/tokio/attr.main.html#usage) except that this gives a name to the async part of the main function.