### PR TITLE
cargo: Use workspace-level license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ pedantic = "warn"
 cognitive_complexity = "warn"
 
 [workspace.package]
+license = "AGPL-3.0-only"
 rust-version = "1.74"
 
 [workspace.dependencies]

--- a/ccc-handlers/Cargo.toml
+++ b/ccc-handlers/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-handlers"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license.workspace = true
 rust-version.workspace = true
 
 [lints]

--- a/ccc-proxy/Cargo.toml
+++ b/ccc-proxy/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-proxy"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license.workspace = true
 rust-version.workspace = true
 
 [lints]

--- a/ccc-routes/Cargo.toml
+++ b/ccc-routes/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-routes"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license.workspace = true
 rust-version.workspace = true
 
 [lints]

--- a/ccc-server/Cargo.toml
+++ b/ccc-server/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-server"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license.workspace = true
 rust-version.workspace = true
 
 [lints]

--- a/ccc-types/Cargo.toml
+++ b/ccc-types/Cargo.toml
@@ -3,6 +3,7 @@ name = "ccc-types"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license.workspace = true
 rust-version.workspace = true
 
 [lints]

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -2,8 +2,8 @@
 name = "e2e"
 version = "0.1.0"
 edition = "2021"
-license = "AGPL-3.0-only"
 description = "End-to-end tests for the project"
+license.workspace = true
 rust-version.workspace = true
 
 [lints]


### PR DESCRIPTION
Since we already had defined the license in a file, this just makes it official that the license for all these crates is AGPL.