### PR TITLE
Prevent publish attempts on the e2e crate

### DIFF
--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -3,6 +3,7 @@ name = "e2e"
 version = "0.1.0"
 edition = "2021"
 description = "End-to-end tests for the project"
+publish = false
 license.workspace = true
 rust-version.workspace = true
 


### PR DESCRIPTION
Like the rest of the crates in this project, this one should probably be marked as `publish: false`.