### PR TITLE
add handlers, routes, types for news wpjson

### DIFF
--- a/ccc-handlers/src/lib.rs
+++ b/ccc-handlers/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bonapp;
 pub mod github;
+pub mod news;
 pub mod reports;
 pub mod streams;

--- a/ccc-handlers/src/news.rs
+++ b/ccc-handlers/src/news.rs
@@ -1,0 +1,59 @@
+use axum::{
+	extract::Query,
+	response::{IntoResponse, Response},
+	Json,
+};
+use http::StatusCode;
+use serde::Deserialize;
+use tracing::instrument;
+
+use ccc_proxy::ProxyError;
+
+#[derive(thiserror::Error, Debug)]
+pub enum NewsProxyError {
+	#[error("error from proxy: {0}")]
+	Proxy(ProxyError),
+
+	#[error("missing required parameter: {0}")]
+	MissingParameter(String),
+}
+
+impl IntoResponse for NewsProxyError {
+	fn into_response(self) -> Response {
+		let (status, text) = match &self {
+			NewsProxyError::MissingParameter(_) => (StatusCode::BAD_REQUEST, self.to_string()),
+			NewsProxyError::Proxy(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+		};
+
+		let body = text.into();
+
+		Response::builder().status(status).body(body).unwrap()
+	}
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WpJsonQuery {
+	url: Option<String>,
+}
+
+#[instrument(skip_all)]
+pub async fn wp_json_handler(
+	Query(query): Query<WpJsonQuery>,
+) -> Result<Json<Vec<ccc_types::news::WpJsonPost>>, NewsProxyError> {
+	let url = query
+		.url
+		.ok_or_else(|| NewsProxyError::MissingParameter("url".to_string()))?;
+
+	let request = ccc_proxy::global_proxy()
+		.client()
+		.get(url)
+		.build()
+		.map_err(ProxyError::ProxiedRequest)
+		.map_err(NewsProxyError::Proxy)?;
+
+	ccc_proxy::global_proxy()
+		.send_request_parse_json::<Vec<ccc_types::news::WpJsonPost>>(request)
+		.await
+		.map(Json)
+		.map_err(NewsProxyError::Proxy)
+}

--- a/ccc-routes/src/lib.rs
+++ b/ccc-routes/src/lib.rs
@@ -2,6 +2,7 @@ pub mod contacts;
 pub mod dictionary;
 pub mod faqs;
 pub mod food;
+pub mod news;
 pub mod printing;
 pub mod reports;
 pub mod spaces;

--- a/ccc-routes/src/news.rs
+++ b/ccc-routes/src/news.rs
@@ -1,0 +1,6 @@
+use axum::{routing::get, Router};
+use ccc_handlers::news::wp_json_handler;
+
+pub fn router() -> Router {
+	Router::new().route("/wpjson", get(wp_json_handler))
+}

--- a/ccc-server/src/main.rs
+++ b/ccc-server/src/main.rs
@@ -43,6 +43,7 @@ fn init_router() -> Router {
 		.nest("/dictionary", ccc_routes::dictionary::router())
 		.nest("/faqs", ccc_routes::faqs::router())
 		.nest("/food", ccc_routes::food::router())
+		.nest("/news", ccc_routes::news::router())
 		.nest("/printing", ccc_routes::printing::router())
 		.nest("/reports", ccc_routes::reports::router())
 		.nest("/spaces", ccc_routes::spaces::router())

--- a/ccc-types/src/lib.rs
+++ b/ccc-types/src/lib.rs
@@ -2,6 +2,7 @@ pub mod contacts;
 pub mod dictionary;
 pub mod faqs;
 pub mod food;
+pub mod news;
 pub mod printing;
 pub mod reports;
 pub mod spaces;

--- a/ccc-types/src/news.rs
+++ b/ccc-types/src/news.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WpJsonResponse {
+	pub posts: Option<Vec<WpJsonPost>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WpJsonPost {
+	pub id: Option<u64>,
+	pub date: Option<String>,
+	pub date_gmt: Option<String>,
+	pub guid: Option<WpJsonGuid>,
+	pub modified: Option<String>,
+	pub modified_gmt: Option<String>,
+	pub slug: Option<String>,
+	pub status: Option<String>,
+	#[serde(rename = "type")]
+	pub type_: Option<String>,
+	pub link: Option<String>,
+	pub title: Option<WpJsonTitle>,
+	pub content: Option<WpJsonContent>,
+	pub excerpt: Option<WpJsonExcerpt>,
+	pub author: Option<u64>,
+	pub featured_media: Option<u64>,
+	pub comment_status: Option<String>,
+	pub ping_status: Option<String>,
+	pub sticky: Option<bool>,
+	pub template: Option<String>,
+	pub format: Option<String>,
+	pub meta: Option<Value>,
+	pub categories: Option<Vec<u64>>,
+	pub tags: Option<Vec<u64>>,
+	pub class_list: Option<Vec<String>>,
+	pub acf: Option<Value>,
+	pub jetpack_featured_media_url: Option<String>,
+	pub jetpack_sharing_enabled: Option<bool>,
+	#[serde(rename = "_links")]
+	pub links: Option<Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WpJsonGuid {
+	pub rendered: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WpJsonTitle {
+	pub rendered: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WpJsonContent {
+	pub rendered: Option<String>,
+	pub protected: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WpJsonExcerpt {
+	pub rendered: Option<String>,
+	pub protected: Option<bool>,
+}


### PR DESCRIPTION
support for news endpoints that use `wpjson` 

usage
```
/api/news/wpjson?url=https://wp.stolaf.edu/wp-json/wp/v2/posts
```
sample of data returned
```json
[{"id":215323,"date":"2025-06-20T10:00:58","date_gmt":"2025-06-20T15:00:58","guid":{"rendered":"https://wp.stolaf.edu/?p=215323"},"modified":"2025-06-20T11:31:15","modified_gmt":"2025-06-20T16:31:15","slug":"st-olaf-faculty-member-named-fulbright-specialist-for-collaborative-teaching-project-in-finland","status":"publish","type":"post","link":"https://wp.stolaf.edu/news/st-olaf-faculty-member-named-fulbright-specialist-for-collaborative-teaching-project-in-finland","title":{"rendered":"St. Olaf faculty member named Fulbright Specialist for project in Finland"},"content":{"rendered":"..."
```